### PR TITLE
Convert rem units to em

### DIFF
--- a/src/app/data-picker/data-picker/data-picker.component.scss
+++ b/src/app/data-picker/data-picker/data-picker.component.scss
@@ -6,6 +6,7 @@ $pickerHeight: 160;
 $middleLayerHeight: 32;
 
 .ng-data-picker {
+  font-size: 1rem;
   height: r($pickerHeight);
   position: relative;
   background-color: transparent;

--- a/src/app/data-picker/data-picker/data-picker.component.scss
+++ b/src/app/data-picker/data-picker/data-picker.component.scss
@@ -1,5 +1,5 @@
 @function r($px) {
-  @return ($px / 16) * 1rem
+  @return ($px / 16) * 1em
 }
 
 $pickerHeight: 160;
@@ -35,7 +35,7 @@ $middleLayerHeight: 32;
     contain: strict;
     height: r($middleLayerHeight);
     line-height: 2;
-    font-size: 1rem;
+    font-size: 1em;
   }
   .selected-item {
 
@@ -52,7 +52,7 @@ $middleLayerHeight: 32;
     .picker-top {
       border-bottom: 0.55px solid #4a4959;
       background: linear-gradient(to bottom, white 2%, rgba(255, 255, 255, 0.1) 100%);
-      transform: translate3d(0, 0, 5.625rem);
+      transform: translate3d(0, 0, 5.625em);
     }
     .picker-middle {
       height: r($middleLayerHeight);
@@ -60,7 +60,7 @@ $middleLayerHeight: 32;
     .picker-bottom {
       border-top: 0.55px solid #4a4959;
       background: linear-gradient(to top, white 2%, rgba(255, 255, 255, 0.1) 100%);
-      transform: translate3d(0, 0, 5.625rem);
+      transform: translate3d(0, 0, 5.625em);
     }
   }
 

--- a/src/app/data-picker/data-picker/data-picker.component.ts
+++ b/src/app/data-picker/data-picker/data-picker.component.ts
@@ -41,7 +41,7 @@ export { PickerDataModel }
   // styleUrls: ['./data-picker.component.scss']
   styles: [`
     .ng-data-picker {
-      height: 10rem;
+      height: 10em;
       position: relative;
       background-color: white;
       overflow: hidden;
@@ -52,9 +52,9 @@ export { PickerDataModel }
     .ng-data-picker .picker-group {
     }
     .ng-data-picker .picker-list {
-      height: 6.25rem;
+      height: 6.25em;
       position: relative;
-      top: 4rem; // half of picker height - half of item height
+      top: 4em; // half of picker height - half of item height
     }
     .ng-data-picker .picker-item {
       position: absolute;
@@ -68,9 +68,9 @@ export { PickerDataModel }
       text-align: center;
       will-change: transform;
       contain: strict;
-      height: 2rem;
+      height: 2em;
       line-height: 2;
-      font-size: 1rem;
+      font-size: 1em;
     }
     .ng-data-picker .selected-item {
     }
@@ -88,15 +88,15 @@ export { PickerDataModel }
     .ng-data-picker .picker-handle-layer .picker-top {
       border-bottom: 0.55px solid rgba(74, 73, 89, 0.5);
       background: linear-gradient(to bottom, white 2%, rgba(255, 255, 255, 0.1) 100%);
-      transform: translate3d(0, 0, 5.625rem);
+      transform: translate3d(0, 0, 5.625em);
     }
     .ng-data-picker .picker-handle-layer .picker-middle {
-      height: 2rem;
+      height: 2em;
     }
     .ng-data-picker .picker-handle-layer .picker-bottom {
       border-top: 0.55px solid rgba(74, 73, 89, 0.5);
       background: linear-gradient(to top, white 2%, rgba(255, 255, 255, 0.1) 100%);
-      transform: translate3d(0, 0, 5.625rem);
+      transform: translate3d(0, 0, 5.625em);
     }
 
     /* flex system */
@@ -427,7 +427,7 @@ export class DataPickerComponent implements OnInit, AfterViewInit, OnDestroy {
     const gapCount = this.currentIndexList[gIndex] - iIndex
     if (Math.abs(gapCount) < (90 / this.itemPerDegree)) {
       const rotateStyle = {
-        transform: 'rotateX(' + gapCount * this.itemPerDegree + 'deg) translate3d(0, 0, 5.625rem)',
+        transform: 'rotateX(' + gapCount * this.itemPerDegree + 'deg) translate3d(0, 0, 5.625em)',
         opacity: (1 - Math.abs(gapCount) / (90 / this.itemPerDegree)).toString()
       }
       if (!this.draggingInfo.isDragging) {
@@ -436,9 +436,9 @@ export class DataPickerComponent implements OnInit, AfterViewInit, OnDestroy {
       return rotateStyle
     }
     if (gapCount > 0) {
-      return { transform: 'rotateX(90deg) translate3d(0, 0, 5.625rem)' }
+      return { transform: 'rotateX(90deg) translate3d(0, 0, 5.625em)' }
     } else {
-      return { transform: 'rotateX(-90deg) translate3d(0, 0, 5.625rem)' }
+      return { transform: 'rotateX(-90deg) translate3d(0, 0, 5.625em)' }
     }
   }
 }

--- a/src/app/data-picker/data-picker/data-picker.component.ts
+++ b/src/app/data-picker/data-picker/data-picker.component.ts
@@ -41,6 +41,7 @@ export { PickerDataModel }
   // styleUrls: ['./data-picker.component.scss']
   styles: [`
     .ng-data-picker {
+      font-size: 1rem;
       height: 10em;
       position: relative;
       background-color: white;


### PR DESCRIPTION
In order to resize the elements of the component, we need to be able to reference local sizing, not that of the root element. Changing all the references to "em" units instead of "rem" allows us to achieve this while maintaining functionality